### PR TITLE
Adjust planning grid to persist subcategory identifiers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1156,7 +1156,7 @@ elif menu == "Planejamento":
     for col in ["Média 6m", "Planejado", "Realizado", "Diferença"]:
         df_mes[col] = pd.to_numeric(df_mes[col], errors="coerce").fillna(0.0)
 
-    df_display = df_mes.drop(columns=["Sub_id"]).copy()
+    df_display = df_mes.copy()
     df_display["Categoria"] = df_display["Categoria"].astype(str)
     df_display["Subcategoria"] = df_display["Subcategoria"].astype(str)
 
@@ -1164,6 +1164,7 @@ elif menu == "Planejamento":
     gb = GridOptionsBuilder.from_dataframe(df_display)
     gb.configure_default_column(editable=False, resizable=True)
     gb.configure_column("Planejado", editable=True)
+    gb.configure_column("Sub_id", hide=True)
     grid = AgGrid(
         df_display,
         gridOptions=gb.build(),
@@ -1181,7 +1182,13 @@ elif menu == "Planejamento":
         for _, row in df_editado.iterrows():
             if "TOTAL" in str(row["Categoria"]).upper():
                 continue
-            sub_id = int(df_mes.loc[df_mes["Subcategoria"]==row["Subcategoria"], "Sub_id"].iloc[0])
+            sub_id = row.get("Sub_id")
+            if pd.isna(sub_id) or sub_id in (None, ""):
+                continue
+            try:
+                sub_id = int(sub_id)
+            except (TypeError, ValueError):
+                continue
             try:
                 val = float(row["Planejado"]) if row["Planejado"] not in (None,"","NaN") else 0.0
             except Exception:


### PR DESCRIPTION
## Summary
- keep Sub_id in the planning grid data while hiding it from the UI so edits preserve the identifier
- save planned values using the provided Sub_id and skip total rows with missing identifiers to avoid duplicates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da790e3318832b8c856d0f9f1a2b60