### PR TITLE
Normalize credit card duplicate detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -900,9 +900,18 @@ elif menu == "Importação":
                             continue
 
                         try:
-                            val = round(float(val), 2)
-                        except:
-                            val = 0.0
+                            val = float(val)
+                        except (TypeError, ValueError):
+                            duplicados.append(False)
+                            continue
+
+                        if eh_cartao and mes_ref_cc and ano_ref_cc:
+                            if val > 0:
+                                val = -abs(val)
+                            else:
+                                val = abs(val)
+
+                        val = round(val, 2)
 
                         desc_norm = _normalize_desc(desc)
 


### PR DESCRIPTION
## Summary
- replicate credit card sign normalization in the import preview duplicate check
- avoid treating unparsable amounts as duplicates by skipping them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac92c6c8c832bb5bc2adb17d18307