### PR TITLE
Add configurable Itaú X0 integration options

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,9 @@
+[itau_openfinance]
+client_id = "8e41eac8-2cb1-3d62-8f09-b36ae2eb3029"
+client_secret = "8e41eac8-2cb1-3d62-8f09-b36ae2eb3029"
+static_access_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI4ZTQxZWFjOC0yY2IxLTNkNjItOGYwOS1iMzZhZTJlYjMwMjkiLCJleHAiOjE3NTk5Mjk4MzQsImlhdCI6MTc1OTkyOTUzNCwic291cmNlIjoic3RzLXNhbmRib3giLCJlbnYiOiJQIiwiZmxvdyI6IkNDIiwic2NvcGUiOiJjYXNobWFuYWdlbWVudC1jb25zdWx0YWJvbGV0b3MtdjEtYXdzLXNjb3BlIiwidXNlcm5hbWUiOiJyc2VsbWlrYWl0aXNAZ21haWwuY29tIiwib3JnYW5pemF0aW9uTmFtZSI6IkF1dG8gQ2FkYXN0cm8ifQ.VpU2u7paU0msZJLVS5dazqHe5Ahc7v4vuyFWF9tCQd4"
+scope = "cashmanagement-consultaboletos-v1-aws-scope"
+base_url = "https://devportal.itau.com.br"
+accounts_endpoint = "/itau-x0/account-statement/v1/accounts"
+transactions_endpoint = "/itau-x0/account-statement/v1/accounts/{account_id}/transactions"
+additional_headers = "{}"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ pip install -r requirements.txt
    certificate = "/app/certs/cert.pem"
    certificate_key = "/app/certs/key.pem"
    scope = "openid accounts transactions"
+   static_access_token = "eyJ..."            # opcional: token estático já obtido
+   static_token_expires_at = "2024-08-30T18:00:00Z"  # ISO 8601 ou timestamp Unix
+   accounts_endpoint = "/open-banking/accounts/v1/accounts"  # opcional
+   transactions_endpoint = "/open-banking/accounts/v1/accounts/{account_id}/transactions"
    # opcional: cabeçalhos adicionais (JSON)
    additional_headers = "{\"x-itau-nonce\": \"...\"}"
    ```
@@ -45,6 +49,6 @@ pip install -r requirements.txt
    - selecionar a conta (`accountId`) e o período desejado;
    - importar as transações diretamente para a base local, utilizando o mesmo fluxo de classificação/edição do upload de arquivos.
 
-4. Caso deseje testar manualmente, é possível informar `client_id`, `client_secret`, `consent_id` e cabeçalhos adicionais diretamente na interface — os valores digitados ficam apenas na sessão atual.
+4. Caso deseje testar manualmente, é possível informar `client_id`, `client_secret`, `consent_id`, token estático, endpoints, cabeçalhos e parâmetros extras diretamente na interface — os valores digitados ficam apenas na sessão atual.
 
 5. Para cartões de crédito cadastrados na aba **Configurações → Contas** com dia de vencimento, continue selecionando o mês/ano de referência antes de importar para que as parcelas futuras sejam geradas corretamente.


### PR DESCRIPTION
## Summary
- allow configuring static JWT tokens, custom endpoints and extra query params for the Itaú integration UI
- extend the Open Finance client to reuse static tokens and send extra parameters when fetching transactions
- document the new settings and add the provided Itaú credentials to `.streamlit/secrets.toml`

## Testing
- python -m compileall app.py openfinance.py

------
https://chatgpt.com/codex/tasks/task_e_68e664cbe870832bbe6269af30ef220e