### PR TITLE
Document consent requirements for Itaú Open Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ pip install -r requirements.txt
 
    > Os arquivos de certificado/ chave devem estar presentes no contêiner (ex.: pasta `certs/`).
 
-3. Acesse o menu **Importação → Open Finance Itaú** no app para:
+3. Antes de importar, siga o [guia de consentimento](docs/itau_open_finance_consent.md) para criar/autorizar o `consentId` necessário e evitar respostas 403 da API.
+4. Acesse o menu **Importação → Open Finance Itaú** no app para:
    - listar contas elegíveis (`Atualizar contas Itaú`);
    - selecionar a conta (`accountId`) e o período desejado;
    - importar as transações diretamente para a base local, utilizando o mesmo fluxo de classificação/edição do upload de arquivos.
 
-4. Caso deseje testar manualmente, é possível informar `client_id`, `client_secret`, `consent_id`, token estático, endpoints, cabeçalhos e parâmetros extras diretamente na interface — os valores digitados ficam apenas na sessão atual.
+5. Caso deseje testar manualmente, é possível informar `client_id`, `client_secret`, `consent_id`, token estático, endpoints, cabeçalhos e parâmetros extras diretamente na interface — os valores digitados ficam apenas na sessão atual.
 
-5. Para cartões de crédito cadastrados na aba **Configurações → Contas** com dia de vencimento, continue selecionando o mês/ano de referência antes de importar para que as parcelas futuras sejam geradas corretamente.
+6. Para cartões de crédito cadastrados na aba **Configurações → Contas** com dia de vencimento, continue selecionando o mês/ano de referência antes de importar para que as parcelas futuras sejam geradas corretamente.

--- a/docs/itau_open_finance_consent.md
+++ b/docs/itau_open_finance_consent.md
@@ -1,0 +1,45 @@
+# Consentimento para contas no Itaú Open Finance
+
+Este guia resume o fluxo necessário para que uma conta corrente fique autorizada a expor extratos via API e evitar o erro **403 Forbidden** ao consultar `/open-banking/accounts/v1/accounts/{accountId}/transactions`.
+
+## 1. Criar um consentimento com escopos de conta
+
+1. Envie um `POST https://api.itau.com.br/open-banking/consents/v1/consents` usando mTLS e o par `client_id`/`client_secret` da aplicação.
+2. Informe os escopos exigidos pela API de extrato:
+
+   ```json
+   {
+     "data": {
+       "permissions": [
+         "ACCOUNTS_READ",
+         "ACCOUNTS_BALANCES_READ",
+         "ACCOUNTS_TRANSACTIONS_READ",
+         "ACCOUNTS_STATEMENTS_READ"
+       ],
+       "expirationDateTime": "2024-12-31T23:59:59Z",
+       "transactionFromDateTime": "2024-01-01T00:00:00Z",
+       "transactionToDateTime": "2024-12-31T23:59:59Z"
+     }
+   }
+   ```
+3. Armazene o `consentId` retornado e apresente o fluxo de autenticação ao titular.
+
+> Dica: caso já possua um consentimento antigo, consulte `GET /open-banking/consents/v1/consents/{consentId}` e verifique se o `status` é `AUTHORISED` e se os `permissions` incluem todos os escopos acima. Caso contrário, gere um novo consentimento.
+
+## 2. Coletar a autorização do titular
+
+1. Redirecione o correntista para o endpoint OAuth do Itaú com `response_type=code`, `scope=openid accounts`, `consent_id=<consentId>` e o `code_challenge`/`state` exigidos.
+2. Após o login e confirmação do titular, troque o `code` recebido por um `access_token` usando `POST https://sts.itau.com.br/api/oauth/token` com `grant_type=authorization_code`.
+3. Guarde o `access_token` e o `refresh_token` para reutilização enquanto o consentimento estiver válido.
+
+## 3. Chamar as APIs de contas e transações
+
+1. Use sempre o `consentId` autorizado na requisição de token ou envie-o no cabeçalho `x-itau-consent-id` quando aplicável.
+2. Preencha os cabeçalhos obrigatórios (`x-itau-apikey`, `x-itau-correlation-id`, `x-fapi-interaction-id`, `x-itau-nonce`) conforme a especificação.
+3. Se o Itaú retornar **403 Forbidden**, confira:
+   - o `status` do consentimento (deve ser `AUTHORISED`);
+   - se a conta do `accountId` está entre as selecionadas pelo titular ao autorizar;
+   - se o token usado foi emitido com o mesmo `consentId` e ainda está vigente;
+   - se os cabeçalhos obrigatórios foram enviados corretamente.
+
+Seguindo esses passos, a conta ficará apta a liberar o extrato via Open Finance e o aplicativo poderá importar as transações sem bloqueios.

--- a/openfinance.py
+++ b/openfinance.py
@@ -175,6 +175,10 @@ class ItauOpenFinanceClient:
             raise OpenFinanceError(f"Falha na chamada HTTP: {exc}") from exc
 
         if response.status_code >= 400:
+            if response.status_code == 403:
+                raise OpenFinanceError(
+                    "Erro 403 ao chamar Itaú Open Finance. Verifique se o consentimento está autorizado, se o token usa o mesmo consentId e revise o guia em 'docs/itau_open_finance_consent.md'."
+                )
             raise OpenFinanceError(
                 f"Erro {response.status_code} ao chamar {url}: {response.text}"
             )


### PR DESCRIPTION
## Summary
- add a dedicated guide explaining how to criar e autorizar consentimentos Itaú Open Finance e evitar o erro 403
- referenciar o guia na seção de integração do README
- melhorar a mensagem de erro 403 no cliente Open Finance apontando para o guia

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66e5c7adc832bb0c1c5e60ba41682