### PR TITLE
Fix Itaú Open Finance base URL

### DIFF
--- a/openfinance.py
+++ b/openfinance.py
@@ -19,7 +19,7 @@ class ItauOpenFinanceConfig:
     client_id: str
     client_secret: str
     consent_id: Optional[str] = None
-    base_url: str = "https://api.itau/open-finance"
+    base_url: str = "https://api.itau.com.br/open-banking"
     token_url: str = "https://sts.itau.com.br/api/oauth/token"
     scope: str = "openid accounts"
     certificate: Optional[str] = None


### PR DESCRIPTION
## Summary
- correct the default Itaú Open Finance base URL so requests hit the documented api.itau.com.br domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67cafd00c832bb9112394a147a414