### PR TITLE
Add AI assistant chat to explore finance data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ streamlit-plotly-events
 plotly
 rapidfuzz
 python-dateutil>=2.8.2
+openai


### PR DESCRIPTION
## Summary
- add OpenAI utilities to build context from transactions and answer questions based only on existing data
- create an "Assistente IA" page with chat-style UI and API key input to converse about finances
- include the OpenAI dependency for the new assistant

## Testing
- python -m py_compile app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d7d53e0e48331bc55a9756eb75dbc)